### PR TITLE
Fix problem about `InterestingPlaceVisitingLogs`

### DIFF
--- a/iOS/Pog/Pog/Store/Store.swift
+++ b/iOS/Pog/Pog/Store/Store.swift
@@ -90,11 +90,10 @@ public class StoreImpl {
                     self.interestingPlacesSubject.send(places)
                 }
                 if let locationSettings = try? self.container.viewContext.fetch(LocationSettings.fetchRequest()) {
-                    if locationSettings.isEmpty {
-                        return
+                    if !locationSettings.isEmpty {
+                        assert(locationSettings.count == 1)
+                        self.locationSettingsSubject.send(locationSettings.last!)
                     }
-                    assert(locationSettings.count == 1)
-                    self.locationSettingsSubject.send(locationSettings.last!)
                 }
                 if let visitingLogs = try? self.container.viewContext.fetch(InterestingPlaceVisitingLog.fetchRequest()) {
                     self.interestingPlaceVisitingLogsSubject.send(visitingLogs)


### PR DESCRIPTION
Fix problem that user cannot fetch `InterestingPlaceVisitingLogs` which occures when `LocationSettings` is not customized by user.